### PR TITLE
feat(physics): implement joint limits for Rapier bonds

### DIFF
--- a/engine/rendering/instanced/RapierBonds.tsx
+++ b/engine/rendering/instanced/RapierBonds.tsx
@@ -102,7 +102,7 @@ export function RapierBonds({ bonds }: RapierBondsProps) {
           if (jointData) {
             const jointHandle = world.createImpulseJoint(jointData, rawBody1, rawBody2, true);
             if (bond.limits && (bond.bondType === 'revolute' || bond.bondType === 'prismatic')) {
-              (jointHandle as any).setLimits(bond.limits[0], bond.limits[1]);
+              (jointHandle as import('@dimforge/rapier3d-compat').RevoluteImpulseJoint | import('@dimforge/rapier3d-compat').PrismaticImpulseJoint).setLimits(bond.limits[0], bond.limits[1]);
             }
             jointsMapRef.current.set(bond.id, jointHandle);
           }

--- a/engine/rendering/instanced/RapierBonds.tsx
+++ b/engine/rendering/instanced/RapierBonds.tsx
@@ -12,7 +12,7 @@ export interface BondDefinition {
   anchor2?: [number, number, number];
   bondType?: BondType;
   axis?: [number, number, number];
-  limits?: [number, number]; // TODO: Limits not yet supported by current Rapier API
+  limits?: [number, number];
 }
 
 export interface RapierBondsProps {
@@ -101,6 +101,9 @@ export function RapierBonds({ bonds }: RapierBondsProps) {
 
           if (jointData) {
             const jointHandle = world.createImpulseJoint(jointData, rawBody1, rawBody2, true);
+            if (bond.limits && (bond.bondType === 'revolute' || bond.bondType === 'prismatic')) {
+              (jointHandle as any).setLimits(bond.limits[0], bond.limits[1]);
+            }
             jointsMapRef.current.set(bond.id, jointHandle);
           }
         } catch (error) {


### PR DESCRIPTION
Implements support for setting joint limits (min/max) for revolute and prismatic joints in the RapierBonds component. Previously, limits were defined in the interface but not applied. This change applies the limits using `setLimits` on the created joint handle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables actual enforcement of joint limits for applicable Rapier bonds.
> 
> - Applies `limits` from `BondDefinition` by calling `setLimits(min, max)` on newly created `revolute` and `prismatic` joints in `RapierBonds`
> - Removes the TODO note and keeps existing creation/removal flows unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 014b40f661b25f340392c67712308375983c3da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->